### PR TITLE
Bugfix/eco 686 there is no cardholder field for credit card payment method

### DIFF
--- a/src/SprykerEco/Yves/Payone/Form/CreditCardSubForm.php
+++ b/src/SprykerEco/Yves/Payone/Form/CreditCardSubForm.php
@@ -79,6 +79,7 @@ class CreditCardSubForm extends AbstractPayoneSubForm
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $this->addCardType($builder, $options)
+            ->addNameOnCard($builder)
             ->addHiddenInputs($builder);
     }
 

--- a/src/SprykerEco/Yves/Payone/Theme/default/credit_card.twig
+++ b/src/SprykerEco/Yves/Payone/Theme/default/credit_card.twig
@@ -21,7 +21,7 @@
 
         <label>{{ 'Payone_credit_card.cardholder' | trans }}</label>
         <div class="field">
-            {{ form_widget(form.payoneCreditCard.cardholder, { 'attr': {'placeholder': 'Payone_credit_card.cardholder' | trans } }) }}
+            {{ form_widget(form.payoneCreditCard.cardholder) }}
             {{ form_errors(form.payoneCreditCard.cardholder) }}
         </div>
 

--- a/src/SprykerEco/Yves/Payone/Theme/default/credit_card.twig
+++ b/src/SprykerEco/Yves/Payone/Theme/default/credit_card.twig
@@ -19,6 +19,12 @@
             <span id="cardexpireyear"></span>
         </span>
 
+        <label>{{ 'Payone_credit_card.cardholder' | trans }}</label>
+        <div class="field">
+            {{ form_widget(form.payoneCreditCard.cardholder, { 'attr': {'placeholder': 'Payone_credit_card.cardholder' | trans } }) }}
+            {{ form_errors(form.payoneCreditCard.cardholder) }}
+        </div>
+
         <div class="field">
             {{ form_widget(form.payoneCreditCard.payone_client_api_config) }}
             {{ form_widget(form.payoneCreditCard.pseudocardpan, {'id': 'pseudocardpan'}) }}


### PR DESCRIPTION
- Developer(s): @sergeysikachev

- Peer Reviewer:

- Ticket: URL_HERE

- Project PR: URL_HERE

- Academy PR: URL_HERE (for feature documentation and if needed migration guides and project integration guide)

#### Please confirm

- [ ] No new OS components - or they have been approved by legal department
- [ ] All new or heavily changed classes get an "A" rating (Scrutinizer), except Facades, Factories, QueryContainers and Tests

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraints         |
   :--------------------- | :------------------------ | :--------------------- |
   Payone               |       major                 |                       |

#### Release Notes

- Added absent cardholder field to the credit card form on payment checkout step.

-----------------------------------------

#### Bundle Payone

_**Major:** Backwards-compatible bug fix_

Def of done (by responsible developer):
- [ ] All changes are backward-compatible. Outdated code is marked as deprecated
- [ ] The change is isolated and not mixed with any cleanups or other changes
- [ ] New code fits to the architecture rules
- [ ] All new or changed business logic is covered by functional tests (in Zed business layer)

##### Change log

Bugfixes

- Added absent cardholder field to the credit card form on payment checkout step.