### PR TITLE
Fix Exception while cancellation

### DIFF
--- a/src/SprykerEco/Zed/Payone/Communication/Plugin/Oms/Command/CancelCommandPlugin.php
+++ b/src/SprykerEco/Zed/Payone/Communication/Plugin/Oms/Command/CancelCommandPlugin.php
@@ -36,6 +36,7 @@ class CancelCommandPlugin extends AbstractPayonePlugin implements CommandByOrder
         $paymentTransfer->setFkSalesOrder($orderEntity->getSpyPaymentPayones()->getFirst()->getFkSalesOrder());
         $captureTransfer->setPayment($paymentTransfer);
         $captureTransfer->setAmount(0);
+        $captureTransfer->setOrder($this->getOrderTransfer($orderEntity));
 
         $this->getFacade()->capturePayment($captureTransfer);
 


### PR DESCRIPTION
When cancelling a order position an exception occurs because the payment is captured again and the CancelCommand does not set the order transfer object.