### PR TITLE
MISC limit SKU length to 32 sybmols

### DIFF
--- a/src/SprykerEco/Zed/Payone/Business/Payment/PaymentManager.php
+++ b/src/SprykerEco/Zed/Payone/Business/Payment/PaymentManager.php
@@ -1128,7 +1128,7 @@ class PaymentManager implements PaymentManagerInterface
 
         foreach ($orderTransfer->getItems() as $itemTransfer) {
             $arrayIt[$key] = PayoneApiConstants::INVOICING_ITEM_TYPE_GOODS;
-            $arrayId[$key] = $itemTransfer->getSku();
+            $arrayId[$key] = substr($itemTransfer->getSku(), 0, 32);
             $arrayPr[$key] = $itemTransfer->getUnitGrossPrice();
             $arrayNo[$key] = $itemTransfer->getQuantity();
             $arrayDe[$key] = $itemTransfer->getName();


### PR DESCRIPTION
Accordgin to https://docs.payone.com/pages/releaseview.action?pageId=1213937, SKU cannot be longer then 32 symbols.
Sending longer ones, will trigger error with code 1611 